### PR TITLE
Torch required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'transformers>=4.3.0',
         'flask',
         "flask_cors",
+        'torch',
     ],
     packages=find_packages(),
     python_requires='>=3',


### PR DESCRIPTION
Even though torch is required for transformers https://github.com/huggingface/transformers/blob/master/setup.py#L136 pip didn't install it. `pip install torch` fixed it but to respect the 1 line idea of the documentation might have to fix that.